### PR TITLE
Remove validation from PageNumber in Pagination class

### DIFF
--- a/EducationCenter.Service/Services/Paginations/Pagination.cs
+++ b/EducationCenter.Service/Services/Paginations/Pagination.cs
@@ -6,7 +6,6 @@ public class Pagination
 {
     private int pageSize;
 
-    [Range(1, int.MaxValue, ErrorMessage = "PageNumber must not be less than 1")]
     public int PageNumber { get; set; } = 1;
 
     public int PageSize


### PR DESCRIPTION
The `PageNumber` property in the `Pagination` class has had its validation annotation removed, allowing for a broader range of values without enforcing a minimum of 1.